### PR TITLE
Export `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,11 @@
   "jsdelivr": "dist/internmap.min.js",
   "unpkg": "dist/internmap.min.js",
   "exports": {
-    "umd": "./dist/internmap.min.js",
-    "default": "./src/index.js"
+    "./package.json": "./package.json",
+    ".": {
+      "umd": "./dist/internmap.min.js",
+      "default": "./src/index.js"
+    }
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Some bundlers attempt to read `package.json`. Trying to use this package with Svelte creates a warning since the `package.json` cannot be accessed